### PR TITLE
Change Vector<T> methods to operate on SIMD types

### DIFF
--- a/thinc_sleef_ops/simd_array/array.hh
+++ b/thinc_sleef_ops/simd_array/array.hh
@@ -14,10 +14,6 @@ struct Array: ArrayBase {
   static size_t const N_FLOAT = Vector<T>::N_FLOAT;
   typedef typename Vector<T>::LOWER_TYPE LOWER_TYPE;
 
-  void add(double *a, size_t n, double v) noexcept;
-
-  void addf(float *a, size_t n, float v) noexcept;
-
   void erf(double *a, size_t n) noexcept;
 
   void erff(float *a, size_t n) noexcept;
@@ -37,14 +33,6 @@ struct Array: ArrayBase {
   void logisticf(double *a, size_t n) noexcept;
 
   void logisticff(float *a, size_t n) noexcept;
-
-  void neg(double *a, size_t n) noexcept;
-
-  void negf(float *a, size_t n) noexcept;
-
-  void recip(double *a, size_t n) noexcept;
-
-  void recipf(float *a, size_t n) noexcept;
 
   void tanh(double *a, size_t n) noexcept;
 

--- a/thinc_sleef_ops/simd_array/array_base.hh
+++ b/thinc_sleef_ops/simd_array/array_base.hh
@@ -14,10 +14,6 @@ struct ArrayBase {
   virtual void geluf_backward(float* a, size_t n) noexcept = 0;
   virtual void logisticf(double *a, size_t n) noexcept = 0;
   virtual void logisticff(float *a, size_t n) noexcept = 0;
-  virtual void neg(double *a, size_t n) noexcept = 0;
-  virtual void negf(float *a, size_t n) noexcept = 0;
-  virtual void recip(double *a, size_t n) noexcept = 0;
-  virtual void recipf(float *a, size_t n) noexcept = 0;
   virtual void tanh(double *a, size_t n) noexcept = 0;
   virtual void tanhf(float *a, size_t n) noexcept = 0;
 };

--- a/thinc_sleef_ops/simd_array/array_impl.hh
+++ b/thinc_sleef_ops/simd_array/array_impl.hh
@@ -55,32 +55,56 @@ struct Array : ArrayBase {
 
   void cdf(double *a, size_t n) noexcept {
     // Φ(x) = 1/2[1 + erf(x/sqrt(2))]
-    Array<T>::mul(a, n, M_SQRT1_2);
-    Array<T>::erf(a, n);
-    Array<T>::add(a, n, 1.0);
-    Array<T>::mul(a, n, 0.5);
+    apply_elementwise(
+      [](double *a) {
+        Vector<T>::mul(a, M_SQRT1_2);
+        Vector<T>::erf(a);
+        Vector<T>::add(a, 1.0);
+        Vector<T>::mul(a, 0.5);
+      },
+      [](double *a, size_t n) { return Array<LOWER_TYPE>().cdf(a, n); },
+      a, n
+    );
   }
 
   void cdff(float *a, size_t n) noexcept {
     // Φ(x) = 1/2[1 + erf(x/sqrt(2))]
-    Array<T>::mulf(a, n, M_SQRT1_2);
-    Array<T>::erff(a, n);
-    Array<T>::addf(a, n, 1.0);
-    Array<T>::mulf(a, n, 0.5);
+    apply_elementwise(
+      [](float *a) {
+        Vector<T>::mulf(a, M_SQRT1_2);
+        Vector<T>::erff(a);
+        Vector<T>::addf(a, 1.0);
+        Vector<T>::mulf(a, 0.5);
+      },
+      [](float *a, size_t n) { return Array<LOWER_TYPE>().cdff(a, n); },
+      a, n
+    );
   }
 
   void pdf(double *a, size_t n) noexcept {
-    Array<T>::mul(a, a, n);
-    Array<T>::mul(a, n, -0.5);
-    Array<T>::exp(a, n);
-    Array<T>::mul(a, n, M_1_SQRT_2PI);
+    apply_elementwise(
+      [](double *a) {
+        Vector<T>::mul(a, a);
+        Vector<T>::mul(a, -0.5);
+        Vector<T>::exp(a);
+        Vector<T>::mul(a, M_1_SQRT_2PI);
+      },
+      [](double *a, size_t n) { return Array<LOWER_TYPE>().pdf(a, n); },
+      a, n
+    );
   }
 
   void pdff(float *a, size_t n) noexcept {
-    Array<T>::mulf(a, a, n);
-    Array<T>::mulf(a, n, -0.5);
-    Array<T>::expf(a, n);
-    Array<T>::mulf(a, n, M_1_SQRT_2PI);
+    apply_elementwise(
+      [](float *a) {
+        Vector<T>::mulf(a, a);
+        Vector<T>::mulf(a, -0.5);
+        Vector<T>::expf(a);
+        Vector<T>::mulf(a, M_1_SQRT_2PI);
+      },
+      [](float *a, size_t n) { return Array<LOWER_TYPE>().pdff(a, n); },
+      a, n
+    );
   }
 
   void erf(double *a, size_t n) noexcept {

--- a/thinc_sleef_ops/simd_vector/vector.hh
+++ b/thinc_sleef_ops/simd_vector/vector.hh
@@ -16,9 +16,45 @@ struct Scalar {};
 template <class T>
 struct Vector {
   typedef Scalar LOWER_TYPE;
+  typedef double DOUBLE_TYPE;
   static size_t const N_DOUBLE = 1;
+  typedef float FLOAT_TYPE;
   static size_t const N_FLOAT = 1;
 };
+
+#define M_1_SQRT_2PI 0.398942280401432677939946059934
+
+template <class T>
+static typename Vector<T>::DOUBLE_TYPE generic_cdf(typename Vector<T>::DOUBLE_TYPE a) {
+  auto r = Vector<T>::mul_scalar(a, M_SQRT1_2);
+  r = Vector<T>::erf(r);
+  r = Vector<T>::add_scalar(r, 1.0);
+  return Vector<T>::mul_scalar(r, 0.5);
+}
+
+template <class T>
+static typename Vector<T>::FLOAT_TYPE generic_cdff(typename Vector<T>::FLOAT_TYPE a) {
+  auto r = Vector<T>::mulf_scalar(a, M_SQRT1_2);
+  r = Vector<T>::erff(r);
+  r = Vector<T>::addf_scalar(r, 1.0);
+  return Vector<T>::mulf_scalar(r, 0.5);
+}
+
+template <class T>
+static typename Vector<T>::DOUBLE_TYPE generic_pdf(typename Vector<T>::DOUBLE_TYPE a) {
+  auto r = Vector<T>::mul(a, a);
+  r = Vector<T>::mul_scalar(r, -0.5);
+  r = Vector<T>::exp(r);
+  return Vector<T>::mul_scalar(r, M_1_SQRT_2PI);
+}
+
+template <class T>
+static typename Vector<T>::FLOAT_TYPE generic_pdff(typename Vector<T>::FLOAT_TYPE a) {
+  auto r = Vector<T>::mulf(a, a);
+  r = Vector<T>::mulf_scalar(r, -0.5);
+  r = Vector<T>::expf(r);
+  return Vector<T>::mulf_scalar(r, M_1_SQRT_2PI);
+}
 
 template<>
 struct Vector<Scalar> {
@@ -30,76 +66,106 @@ struct Vector<Scalar> {
 
   typedef Scalar LOWER_TYPE;
 
-  static void add(double *a, double v) noexcept {
-    *a += v;
+  static DOUBLE_TYPE add(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return a + b;
   }
 
-  static void add(double *a, double *v) noexcept {
-    *a += *v;
+  static DOUBLE_TYPE add_scalar(DOUBLE_TYPE a, double b) noexcept {
+    return a + b;
   }
 
-  static void addf(float *a, float v) noexcept {
-    *a += v;
+  static FLOAT_TYPE addf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return a + b;
   }
 
-  static void addf(float *a, float *v) noexcept {
-    *a += *v;
+  static FLOAT_TYPE addf_scalar(FLOAT_TYPE a, float b) noexcept {
+    return a + b;
   }
 
-  static void erf(double *a) noexcept {
-    *a = std::erf(*a);
+  static DOUBLE_TYPE cdf(DOUBLE_TYPE a) {
+    return generic_cdf<Scalar>(a);
   }
 
-  static void erff(float *a) noexcept {
-    *a = std::erf(*a);
+  static FLOAT_TYPE cdff(FLOAT_TYPE a) {
+    return generic_cdff<Scalar>(a);
   }
 
-  static void exp(double *a) noexcept {
-    *a = std::exp(*a);
+  static DOUBLE_TYPE erf(DOUBLE_TYPE a) noexcept {
+    return std::erf(a);
   }
 
-  static void expf(float *a) noexcept {
-    *a = std::exp(*a);
+  static FLOAT_TYPE erff(FLOAT_TYPE a) noexcept {
+    return std::erf(a);
   }
 
-  static void mulf(float *a, float v) noexcept {
-    *a *= v;
+  static DOUBLE_TYPE exp(DOUBLE_TYPE a) noexcept {
+    return std::exp(a);
   }
 
-  static void mulf(float *a, float *v) noexcept {
-    *a *= *v;
+  static FLOAT_TYPE expf(FLOAT_TYPE a) noexcept {
+    return std::exp(a);
   }
 
-  static void mul(double *a, double v) noexcept {
-    *a *= v;
+  static DOUBLE_TYPE mul(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return a * b;
   }
 
-  static void mul(double *a, double *v) noexcept {
-    *a *= *v;
+  static DOUBLE_TYPE mul_scalar(DOUBLE_TYPE a, double b) noexcept {
+    return a * b;
   }
 
-  static void neg(double *a) noexcept {
-    *a = -*a;
+  static FLOAT_TYPE mulf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return a * b;
   }
 
-  static void negf(float *a) noexcept {
-    *a = -*a;
+  static FLOAT_TYPE mulf_scalar(FLOAT_TYPE a, float b) noexcept {
+    return a * b;
   }
 
-  static void recip(double *a) noexcept {
-    *a = 1.0 / *a;
+  static DOUBLE_TYPE neg(DOUBLE_TYPE a) noexcept {
+    return -a;
   }
 
-  static void recipf(float *a) noexcept {
-    *a = 1.0 / *a;
+  static FLOAT_TYPE negf(FLOAT_TYPE a) noexcept {
+    return -a;
   }
 
-  static void tanh(double *a) noexcept {
-    *a = Sleef_tanh_u10(*a);
+  static DOUBLE_TYPE pdf(DOUBLE_TYPE a) {
+    return generic_pdf<Scalar>(a);
   }
 
-  static void tanhf(float *a) noexcept {
-    *a = Sleef_tanhf_u10(*a);
+  static FLOAT_TYPE pdff(FLOAT_TYPE a) {
+    return generic_pdff<Scalar>(a);
+  }
+
+  static DOUBLE_TYPE recip(DOUBLE_TYPE a) noexcept {
+    return 1.0 / a;
+  }
+
+  static FLOAT_TYPE recipf(FLOAT_TYPE a) noexcept {
+    return 1.0 / a;
+  }
+
+  static DOUBLE_TYPE tanh(DOUBLE_TYPE a) noexcept {
+    return Sleef_tanh_u10(a);
+  }
+
+  static FLOAT_TYPE tanhf(FLOAT_TYPE a) noexcept {
+    return Sleef_tanhf_u10(a);
+  }
+
+  template <class F>
+  static void with_load_store(F f, float *a) noexcept {
+    FLOAT_TYPE val = *a;
+    val = f(val);
+    *a = val;
+  }
+
+  template <class F>
+  static void with_load_store(F f, double *a) noexcept {
+    DOUBLE_TYPE val = *a;
+    val = f(val);
+    *a = val;
   }
 };
 

--- a/thinc_sleef_ops/simd_vector/vector_avx.hh
+++ b/thinc_sleef_ops/simd_vector/vector_avx.hh
@@ -18,103 +18,102 @@ struct Vector<AVX> {
 
   typedef SSE LOWER_TYPE;
 
-  static void add(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = _mm256_set1_pd(v);
-      return _mm256_add_pd(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE add(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return _mm256_add_pd(a, b);
   }
 
-  static void add(double *a, double *v) noexcept {
-    with_load_load_store(_mm256_add_pd, a, v);
+  static DOUBLE_TYPE add_scalar(DOUBLE_TYPE a, double b) noexcept {
+    DOUBLE_TYPE b_simd = _mm256_set1_pd(b);
+    return _mm256_add_pd(a, b_simd);
   }
 
-  static void addf(float *a, float v) noexcept {
-    with_load_store([=](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = _mm256_set1_ps(v);
-      return _mm256_add_ps(a, v_simd);
-    }, a);
+  static FLOAT_TYPE addf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return _mm256_add_ps(a, b);
   }
 
-  static void addf(float *a, float *v) noexcept {
-    with_load_load_store(_mm256_add_ps, a, v);
+  static FLOAT_TYPE addf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE b_simd = _mm256_set1_ps(b);
+    return _mm256_add_ps(a, b_simd);
   }
 
-  static void erf(double *a) {
-    with_load_store(Sleef_erfd4_u10, a);
+  static DOUBLE_TYPE cdf(DOUBLE_TYPE a) {
+    return generic_cdf<AVX>(a);
   }
 
-  static void erff(float *a) {
-    with_load_store(Sleef_erff8_u10, a);
+  static FLOAT_TYPE cdff(FLOAT_TYPE a) {
+    return generic_cdff<AVX>(a);
   }
 
-  static void expf(float *a) {
-    with_load_store(Sleef_expf8_u10, a);
+  static DOUBLE_TYPE erf(DOUBLE_TYPE a) {
+    return Sleef_erfd4_u10(a);
   }
 
-  static void exp(double *a) {
-    with_load_store(Sleef_expd4_u10, a);
+  static FLOAT_TYPE erff(FLOAT_TYPE a) {
+    return Sleef_erff8_u10(a);
   }
 
-  static void mul(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = _mm256_set1_pd(v);
-      return _mm256_mul_pd(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE exp(DOUBLE_TYPE a) {
+    return Sleef_expd4_u10(a);
   }
 
-  static void mul(double *a, double *v) noexcept {
-    with_load_load_store(_mm256_mul_pd, a, v);
+  static FLOAT_TYPE expf(FLOAT_TYPE a) {
+    return Sleef_expf8_u10(a);
   }
 
-  static void mulf(float *a, float v) noexcept {
-    with_load_store([v](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = _mm256_set1_ps(v);
-      return _mm256_mul_ps(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE mul(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return _mm256_mul_pd(a, b);
   }
 
-  static void mulf(float *a, float *v) noexcept {
-    with_load_load_store(_mm256_mul_ps, a, v);
+  static DOUBLE_TYPE mul_scalar(DOUBLE_TYPE a, double b) noexcept {
+    DOUBLE_TYPE b_simd = _mm256_set1_pd(b);
+    return _mm256_mul_pd(a, b_simd);
   }
 
-  static void neg(double *a) noexcept {
-    with_load_store([](DOUBLE_TYPE v) {
-      DOUBLE_TYPE minus_zero = _mm256_set1_pd(-0.0);
-      return _mm256_xor_pd(v, minus_zero);
-    }, a);
+  static FLOAT_TYPE mulf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return _mm256_mul_ps(a, b);
   }
 
-  static void negf(float *a) noexcept {
-    with_load_store([](FLOAT_TYPE v) {
-      FLOAT_TYPE minus_zero = _mm256_set1_ps(-0.0);
-      return _mm256_xor_ps(v, minus_zero);
-    }, a);
+  static FLOAT_TYPE mulf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE b_simd = _mm256_set1_ps(b);
+    return _mm256_mul_ps(a, b_simd);
   }
 
-  static void recip(double *a) noexcept {
-    with_load_store([](DOUBLE_TYPE v) {
-      DOUBLE_TYPE one = _mm256_set1_pd(1.0);
-      return _mm256_div_pd(one, v);
-    }, a);
+  static DOUBLE_TYPE neg(DOUBLE_TYPE a) noexcept {
+    DOUBLE_TYPE minus_zero = _mm256_set1_pd(-0.0);
+    return _mm256_xor_pd(a, minus_zero);
   }
 
-  static void recipf(float *a) noexcept {
-    with_load_store([](FLOAT_TYPE v) {
-      FLOAT_TYPE one = _mm256_set1_ps(1.0);
-      return _mm256_div_ps(one, v);
-    }, a);
+  static FLOAT_TYPE negf(FLOAT_TYPE a) noexcept {
+    FLOAT_TYPE minus_zero = _mm256_set1_ps(-0.0);
+    return _mm256_xor_ps(a, minus_zero);
   }
 
-  static void tanh(double *a) {
-    with_load_store(Sleef_tanhd4_u10, a);
+  static DOUBLE_TYPE pdf(DOUBLE_TYPE a) {
+    return generic_pdf<AVX>(a);
   }
 
-  static void tanhf(float *a) {
-    with_load_store(Sleef_tanhf8_u10, a);
+  static FLOAT_TYPE pdff(FLOAT_TYPE a) {
+    return generic_pdff<AVX>(a);
   }
 
-private:
+  static DOUBLE_TYPE recip(DOUBLE_TYPE a) noexcept {
+    DOUBLE_TYPE one = _mm256_set1_pd(1.0);
+    return _mm256_div_pd(one, a);
+  }
+
+  static FLOAT_TYPE recipf(FLOAT_TYPE a) noexcept {
+    FLOAT_TYPE one = _mm256_set1_ps(1.0);
+    return _mm256_div_ps(one, a);
+  }
+
+  static DOUBLE_TYPE tanh(DOUBLE_TYPE a) {
+    return Sleef_tanhd4_u10(a);
+  }
+
+  static FLOAT_TYPE tanhf(FLOAT_TYPE a) {
+    return Sleef_tanhf8_u10(a);
+  }
+
   template <class F>
   static void with_load_store(F f, float *a) {
     FLOAT_TYPE val = _mm256_loadu_ps(a);
@@ -127,22 +126,6 @@ private:
     DOUBLE_TYPE val = _mm256_loadu_pd(a);
     val = f(val);
     _mm256_storeu_pd(a, val);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, double *a, double *b) noexcept {
-    DOUBLE_TYPE val_a = _mm256_loadu_pd(a);
-    DOUBLE_TYPE val_b = _mm256_loadu_pd(b);
-    val_a = f(val_a, val_b);
-    _mm256_storeu_pd(a, val_a);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, float *a, float *b) noexcept {
-    FLOAT_TYPE val_a = _mm256_loadu_ps(a);
-    FLOAT_TYPE val_b = _mm256_loadu_ps(b);
-    val_a = f(val_a, val_b);
-    _mm256_storeu_ps(a, val_a);
   }
 };
 

--- a/thinc_sleef_ops/simd_vector/vector_avx512.hh
+++ b/thinc_sleef_ops/simd_vector/vector_avx512.hh
@@ -30,107 +30,106 @@ struct Vector<AVX512> {
 
   typedef AVX LOWER_TYPE;
 
-  static void add(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = _mm512_set1_pd(v);
-      return _mm512_add_pd(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE add(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return _mm512_add_pd(a, b);
   }
 
-  static void add(double *a, double *v) noexcept {
-    with_load_load_store(_mm512_add_pd, a, v);
+  static DOUBLE_TYPE add_scalar(DOUBLE_TYPE a, double b) noexcept {
+    DOUBLE_TYPE b_simd = _mm512_set1_pd(b);
+    return _mm512_add_pd(a, b_simd);
   }
 
-  static void addf(float *a, float v) noexcept {
-    with_load_store([=](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = _mm512_set1_ps(v);
-      return _mm512_add_ps(a, v_simd);
-    }, a);
+  static FLOAT_TYPE addf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return _mm512_add_ps(a, b);
   }
 
-  static void addf(float *a, float *v) noexcept {
-    with_load_load_store(_mm512_add_ps, a, v);
+  static FLOAT_TYPE addf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE b_simd = _mm512_set1_ps(b);
+    return _mm512_add_ps(a, b_simd);
   }
 
-  static void erf(double *a) {
-    with_load_store(Sleef_erfd8_u10, a);
+  static DOUBLE_TYPE cdf(DOUBLE_TYPE a) {
+    return generic_cdf<AVX512>(a);
   }
 
-  static void erff(float *a) {
-    with_load_store(Sleef_erff16_u10, a);
+  static FLOAT_TYPE cdff(FLOAT_TYPE a) {
+    return generic_cdff<AVX512>(a);
   }
 
-  static void exp(double *a) {
-    with_load_store(Sleef_expd8_u10, a);
+  static DOUBLE_TYPE erf(DOUBLE_TYPE a) {
+    return Sleef_erfd8_u10(a);
   }
 
-  static void expf(float *a) {
-    with_load_store(Sleef_expf16_u10, a);
+  static FLOAT_TYPE erff(FLOAT_TYPE a) {
+    return Sleef_erff16_u10(a);
   }
 
-  static void mul(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = _mm512_set1_pd(v);
-      return _mm512_mul_pd(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE exp(DOUBLE_TYPE a) {
+    return Sleef_expd8_u10(a);
   }
 
-  static void mul(double *a, double *v) noexcept {
-    with_load_load_store(_mm512_mul_pd, a, v);
+  static FLOAT_TYPE expf(FLOAT_TYPE a) {
+    return Sleef_expf16_u10(a);
   }
 
-  static void mulf(float *a, float v) noexcept {
-    with_load_store([v](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = _mm512_set1_ps(v);
-      return _mm512_mul_ps(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE mul(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return _mm512_mul_pd(a, b);
   }
 
-  static void mulf(float *a, float *v) noexcept {
-    with_load_load_store(_mm512_mul_ps, a, v);
+  static DOUBLE_TYPE mul_scalar(DOUBLE_TYPE a, double b) noexcept {
+    DOUBLE_TYPE b_simd = _mm512_set1_pd(b);
+    return _mm512_mul_pd(a, b_simd);
   }
 
-  static void neg(double *a) noexcept {
-    with_load_store([](DOUBLE_TYPE v) {
-      DOUBLE_TYPE minus_zero = _mm512_set1_pd(-0.0);
-      return _mm512_xor_pd(v, minus_zero);
-    }, a);
+  static FLOAT_TYPE mulf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return _mm512_mul_ps(a, b);
   }
 
-  static void negf(float *a) noexcept {
-    with_load_store([](FLOAT_TYPE v) {
-      FLOAT_TYPE minus_zero = _mm512_set1_ps(-0.0);
-      return _mm512_xor_ps(v, minus_zero);
-    }, a);
+  static FLOAT_TYPE mulf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE b_simd = _mm512_set1_ps(b);
+    return _mm512_mul_ps(a, b_simd);
   }
 
-  static void recip(double *a) noexcept {
-    with_load_store([](DOUBLE_TYPE v) {
-      // Use division rather than reciprocal instruction, for
-      // higher precision. Not sure if we care?
-      DOUBLE_TYPE one = _mm512_set1_pd(1.0);
-      return _mm512_div_pd(one, v);
-    }, a);
+  static DOUBLE_TYPE neg(DOUBLE_TYPE a) noexcept {
+    DOUBLE_TYPE minus_zero = _mm512_set1_pd(-0.0);
+    return _mm512_xor_pd(a, minus_zero);
   }
 
-  static void recipf(float *a) noexcept {
-    with_load_store([](FLOAT_TYPE v) {
-      // Use division rather than reciprocal instruction, for
-      // higher precision. Not sure if we care?
-      FLOAT_TYPE one = _mm512_set1_ps(1.0);
-      return _mm512_div_ps(one, v);
-    }, a);
+  static DOUBLE_TYPE pdf(DOUBLE_TYPE a) {
+    return generic_pdf<AVX512>(a);
   }
 
-  static void tanh(double *a) {
-    with_load_store(Sleef_tanhd8_u10, a);
+  static FLOAT_TYPE pdff(FLOAT_TYPE a) {
+    return generic_pdff<AVX512>(a);
   }
 
-  static void tanhf(float *a) {
-    with_load_store(Sleef_tanhf16_u10, a);
+  static FLOAT_TYPE negf(FLOAT_TYPE a) noexcept {
+    FLOAT_TYPE minus_zero = _mm512_set1_ps(-0.0);
+    return _mm512_xor_ps(a, minus_zero);
   }
 
-private:
+  static DOUBLE_TYPE recip(DOUBLE_TYPE a) noexcept {
+    // Use division rather than reciprocal instruction, for
+    // higher precision. Not sure if we care?
+    DOUBLE_TYPE one = _mm512_set1_pd(1.0);
+    return _mm512_div_pd(one, a);
+  }
+
+  static FLOAT_TYPE recipf(FLOAT_TYPE a) noexcept {
+    // Use division rather than reciprocal instruction, for
+    // higher precision. Not sure if we care?
+    FLOAT_TYPE one = _mm512_set1_ps(1.0);
+    return _mm512_div_ps(one, a);
+  }
+
+  static DOUBLE_TYPE tanh(DOUBLE_TYPE a) {
+    return Sleef_tanhd8_u10(a);
+  }
+
+  static FLOAT_TYPE tanhf(FLOAT_TYPE a) {
+    return Sleef_tanhf16_u10(a);
+  }
+
   template <class F>
   static void with_load_store(F f, float *a) {
     FLOAT_TYPE val = _mm512_loadu_ps(a);
@@ -143,22 +142,6 @@ private:
     DOUBLE_TYPE val = _mm512_loadu_pd(a);
     val = f(val);
     _mm512_storeu_pd(a, val);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, double *a, double *b) noexcept {
-    DOUBLE_TYPE val_a = _mm512_loadu_pd(a);
-    DOUBLE_TYPE val_b = _mm512_loadu_pd(b);
-    val_a = f(val_a, val_b);
-    _mm512_storeu_pd(a, val_a);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, float *a, float *b) noexcept {
-    FLOAT_TYPE val_a = _mm512_loadu_ps(a);
-    FLOAT_TYPE val_b = _mm512_loadu_ps(b);
-    val_a = f(val_a, val_b);
-    _mm512_storeu_ps(a, val_a);
   }
 };
 

--- a/thinc_sleef_ops/simd_vector/vector_neon.hh
+++ b/thinc_sleef_ops/simd_vector/vector_neon.hh
@@ -18,97 +18,100 @@ struct Vector<NEON> {
 
   typedef Scalar LOWER_TYPE;
 
-  static void add(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = vdupq_n_f64(v);
-      return vaddq_f64(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE add_scalar(DOUBLE_TYPE a, double b) noexcept {
+    DOUBLE_TYPE v_simd = vdupq_n_f64(b);
+    return vaddq_f64(a, v_simd);
   }
 
-  static void add(double *a, double *v) noexcept {
-    with_load_load_store(vaddq_f64, a, v);
+  static DOUBLE_TYPE add(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return vaddq_f64(a, b);
   }
 
-  static void addf(float *a, float v) noexcept {
-    with_load_store([=](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = vdupq_n_f32(v);
-      return vaddq_f32(a, v_simd);
-    }, a);
+  static FLOAT_TYPE addf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE v_simd = vdupq_n_f32(b);
+    return vaddq_f32(a, v_simd);
   }
 
-  static void addf(float *a, float *v) noexcept {
-    with_load_load_store(vaddq_f32, a, v);
+  static FLOAT_TYPE addf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return vaddq_f32(a, b);
   }
 
-  static void erf(double *a) noexcept {
-    with_load_store(Sleef_erfd2_u10, a);
+  static DOUBLE_TYPE cdf(DOUBLE_TYPE a) {
+    return generic_cdf<NEON>(a);
   }
 
-  static void erff(float *a) noexcept {
-    with_load_store(Sleef_erff4_u10, a);
+  static FLOAT_TYPE cdff(FLOAT_TYPE a) {
+    return generic_cdff<NEON>(a);
   }
 
-  static void exp(double *a) noexcept {
-    with_load_store(Sleef_expd2_u10, a);
+  static DOUBLE_TYPE erf(DOUBLE_TYPE a) noexcept {
+    return Sleef_erfd2_u10(a);
   }
 
-  static void expf(float *a) noexcept {
-    with_load_store(Sleef_expf4_u10, a);
+  static FLOAT_TYPE erff(FLOAT_TYPE a) noexcept {
+    return Sleef_erff4_u10(a);
   }
 
-  static void mul(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = vdupq_n_f64(v);
-      return vmulq_f64(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE exp(DOUBLE_TYPE a) noexcept {
+    return Sleef_expd2_u10(a);
   }
 
-  static void mul(double *a, double *v) noexcept {
-    with_load_load_store(vmulq_f64, a, v);
+  static FLOAT_TYPE expf(FLOAT_TYPE a) noexcept {
+    return Sleef_expf4_u10(a);
   }
 
-  static void mulf(float *a, float v) noexcept {
-    with_load_store([v](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = vdupq_n_f32(v);
-      return vmulq_f32(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE mul(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return vmulq_f64(a, b);
   }
 
-  static void mulf(float *a, float *v) noexcept {
-    with_load_load_store(vmulq_f32, a, v);
+  static DOUBLE_TYPE mul_scalar(FLOAT_TYPE a, double b) noexcept {
+    DOUBLE_TYPE v_simd = vdupq_n_f64(b);
+    return vmulq_f64(a, v_simd);
   }
 
-  static void neg(double *a) noexcept {
-    with_load_store(vnegq_f64, a);
+  static FLOAT_TYPE mulf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return vmulq_f32(a, b);
   }
 
-  static void negf(float *a) noexcept {
-    with_load_store(vnegq_f32, a);
+  static FLOAT_TYPE mulf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE v_simd = vdupq_n_f32(b);
+    return vmulq_f32(a, v_simd);
   }
 
-  static void recip(double *a) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE one = vdupq_n_f64(1);
-      return vdivq_f64(one, a);
-    }, a);
+  static DOUBLE_TYPE neg(DOUBLE_TYPE a) noexcept {
+    return vnegq_f64(a);
   }
 
-  static void recipf(float *a) noexcept {
-    with_load_store([=](FLOAT_TYPE a){
-      FLOAT_TYPE one = vdupq_n_f32(1);
-      return vdivq_f32(one, a);
-    }, a);
+  static FLOAT_TYPE negf(FLOAT_TYPE a) noexcept {
+    return vnegq_f32(a);
   }
 
-  static void tanh(double *a) noexcept {
-    with_load_store(Sleef_tanhd2_u10, a);
+  static DOUBLE_TYPE pdf(DOUBLE_TYPE a) {
+    return generic_pdf<NEON>(a);
   }
 
-  static void tanhf(float *a) noexcept {
-    with_load_store(Sleef_tanhf4_u10, a);
+  static FLOAT_TYPE pdff(FLOAT_TYPE a) {
+    return generic_pdff<NEON>(a);
   }
 
-private:
+  static DOUBLE_TYPE recip(DOUBLE_TYPE a) noexcept {
+    DOUBLE_TYPE one = vdupq_n_f64(1);
+    return vdivq_f64(one, a);
+  }
+
+  static FLOAT_TYPE recipf(FLOAT_TYPE a) noexcept {
+    FLOAT_TYPE one = vdupq_n_f32(1);
+    return vdivq_f32(one, a);
+  }
+
+  static DOUBLE_TYPE tanh(DOUBLE_TYPE a) noexcept {
+    return Sleef_tanhd2_u10(a);
+  }
+
+  static FLOAT_TYPE tanhf(FLOAT_TYPE a) noexcept {
+    return Sleef_tanhf4_u10(a);
+  }
+
   template <class F>
   static void with_load_store(F f, float *a) noexcept {
     FLOAT_TYPE val = vld1q_f32(a);
@@ -121,22 +124,6 @@ private:
     DOUBLE_TYPE val = vld1q_f64(a);
     val = f(val);
     vst1q_f64(a, val);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, double *a, double *b) noexcept {
-    DOUBLE_TYPE val_a = vld1q_f64(a);
-    DOUBLE_TYPE val_b = vld1q_f64(b);
-    val_a = f(val_a, val_b);
-    vst1q_f64(a, val_a);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, float *a, float *b) noexcept {
-    FLOAT_TYPE val_a = vld1q_f32(a);
-    FLOAT_TYPE val_b = vld1q_f32(b);
-    val_a = f(val_a, val_b);
-    vst1q_f32(a, val_a);
   }
 };
 

--- a/thinc_sleef_ops/simd_vector/vector_sse.hh
+++ b/thinc_sleef_ops/simd_vector/vector_sse.hh
@@ -18,103 +18,102 @@ struct Vector<SSE> {
 
   typedef Scalar LOWER_TYPE;
 
-  static void add(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = _mm_set1_pd(v);
-      return _mm_add_pd(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE add(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return _mm_add_pd(a, b);
   }
 
-  static void add(double *a, double *v) noexcept {
-    with_load_load_store(_mm_add_pd, a, v);
+  static DOUBLE_TYPE add_scalar(DOUBLE_TYPE a, double b) noexcept {
+    DOUBLE_TYPE b_simd = _mm_set1_pd(b);
+    return _mm_add_pd(a, b_simd);
   }
 
-  static void addf(float *a, float v) noexcept {
-    with_load_store([=](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = _mm_set1_ps(v);
-      return _mm_add_ps(a, v_simd);
-    }, a);
+  static FLOAT_TYPE addf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return _mm_add_ps(a, b);
   }
 
-  static void addf(float *a, float *v) noexcept {
-    with_load_load_store(_mm_add_ps, a, v);
+  static FLOAT_TYPE addf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE b_simd = _mm_set1_ps(b);
+    return _mm_add_ps(a, b_simd);
   }
 
-  static void erf(double *a) noexcept {
-    with_load_store(Sleef_erfd2_u10, a);
+  static DOUBLE_TYPE cdf(DOUBLE_TYPE a) {
+    return generic_cdf<SSE>(a);
   }
 
-  static void erff(float *a) noexcept {
-    with_load_store(Sleef_erff4_u10, a);
+  static FLOAT_TYPE cdff(FLOAT_TYPE a) {
+    return generic_cdff<SSE>(a);
   }
 
-  static void exp(double *a) noexcept {
-    with_load_store(Sleef_expd2_u10, a);
+  static DOUBLE_TYPE erf(DOUBLE_TYPE a) noexcept {
+    return Sleef_erfd2_u10(a);
   }
 
-  static void expf(float *a) noexcept {
-    with_load_store(Sleef_expf4_u10, a);
+  static FLOAT_TYPE erff(FLOAT_TYPE a) noexcept {
+    return Sleef_erff4_u10(a);
   }
 
-  static void mul(double *a, double v) noexcept {
-    with_load_store([=](DOUBLE_TYPE a){
-      DOUBLE_TYPE v_simd = _mm_set1_pd(v);
-      return _mm_mul_pd(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE exp(DOUBLE_TYPE a) noexcept {
+    return Sleef_expd2_u10(a);
   }
 
-  static void mul(double *a, double *v) noexcept {
-    with_load_load_store(_mm_mul_pd, a, v);
+  static FLOAT_TYPE expf(FLOAT_TYPE a) noexcept {
+    return Sleef_expf4_u10(a);
   }
 
-  static void mulf(float *a, float v) noexcept {
-    with_load_store([v](FLOAT_TYPE a){
-      FLOAT_TYPE v_simd = _mm_set1_ps(v);
-      return _mm_mul_ps(a, v_simd);
-    }, a);
+  static DOUBLE_TYPE mul(DOUBLE_TYPE a, DOUBLE_TYPE b) noexcept {
+    return _mm_mul_pd(a, b);
   }
 
-  static void mulf(float *a, float *v) noexcept {
-    with_load_load_store(_mm_mul_ps, a, v);
+  static DOUBLE_TYPE mul_scalar(DOUBLE_TYPE a, double b) noexcept {
+    DOUBLE_TYPE b_simd = _mm_set1_pd(b);
+    return _mm_mul_pd(a, b_simd);
   }
 
-  static void neg(double *a) noexcept {
-    with_load_store([](DOUBLE_TYPE v) {
-      DOUBLE_TYPE minus_zero = _mm_set1_pd(-0.0);
-      return _mm_xor_pd(v, minus_zero);
-    }, a);
+  static FLOAT_TYPE mulf(FLOAT_TYPE a, FLOAT_TYPE b) noexcept {
+    return _mm_mul_ps(a, b);
   }
 
-  static void negf(float *a) noexcept {
-    with_load_store([](FLOAT_TYPE v) {
-      FLOAT_TYPE minus_zero = _mm_set1_ps(-0.0);
-      return _mm_xor_ps(v, minus_zero);
-    }, a);
+  static FLOAT_TYPE mulf_scalar(FLOAT_TYPE a, float b) noexcept {
+    FLOAT_TYPE b_simd = _mm_set1_ps(b);
+    return _mm_mul_ps(a, b_simd);
   }
 
-  static void recip(double *a) noexcept {
-    with_load_store([](DOUBLE_TYPE v) {
-      DOUBLE_TYPE one = _mm_set1_pd(1.0);
-      return _mm_div_pd(one, v);
-    }, a);
+  static DOUBLE_TYPE neg(DOUBLE_TYPE a) noexcept {
+    DOUBLE_TYPE minus_zero = _mm_set1_pd(-0.0);
+    return _mm_xor_pd(a, minus_zero);
   }
 
-  static void recipf(float *a) noexcept {
-    with_load_store([](FLOAT_TYPE v) {
-      FLOAT_TYPE one = _mm_set1_ps(1.0);
-      return _mm_div_ps(one, v);
-    }, a);
+  static FLOAT_TYPE negf(FLOAT_TYPE a) noexcept {
+    FLOAT_TYPE minus_zero = _mm_set1_ps(-0.0);
+    return _mm_xor_ps(a, minus_zero);
   }
 
-  static void tanh(double *a) noexcept {
-    with_load_store(Sleef_tanhd2_u10, a);
+  static DOUBLE_TYPE pdf(DOUBLE_TYPE a) {
+    return generic_pdf<SSE>(a);
   }
 
-  static void tanhf(float *a) noexcept {
-    with_load_store(Sleef_tanhf4_u10, a);
+  static FLOAT_TYPE pdff(FLOAT_TYPE a) {
+    return generic_pdff<SSE>(a);
   }
 
-private:
+  static DOUBLE_TYPE recip(DOUBLE_TYPE a) noexcept {
+    DOUBLE_TYPE one = _mm_set1_pd(1.0);
+    return _mm_div_pd(one, a);
+  }
+
+  static FLOAT_TYPE recipf(FLOAT_TYPE a) noexcept {
+    FLOAT_TYPE one = _mm_set1_ps(1.0);
+    return _mm_div_ps(one, a);
+  }
+
+  static DOUBLE_TYPE tanh(DOUBLE_TYPE a) noexcept {
+    return Sleef_tanhd2_u10(a);
+  }
+
+  static FLOAT_TYPE tanhf(FLOAT_TYPE a) noexcept {
+    return Sleef_tanhf4_u10(a);
+  }
+
   template <class F>
   static void with_load_store(F f, float *a) noexcept {
     FLOAT_TYPE val = _mm_loadu_ps(a);
@@ -127,22 +126,6 @@ private:
     DOUBLE_TYPE val = _mm_loadu_pd(a);
     val = f(val);
     _mm_storeu_pd(a, val);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, double *a, double *b) noexcept {
-    DOUBLE_TYPE val_a = _mm_loadu_pd(a);
-    DOUBLE_TYPE val_b = _mm_loadu_pd(b);
-    val_a = f(val_a, val_b);
-    _mm_storeu_pd(a, val_a);
-  }
-
-  template <class F>
-  static void with_load_load_store(F f, float *a, float *b) noexcept {
-    FLOAT_TYPE val_a = _mm_loadu_ps(a);
-    FLOAT_TYPE val_b = _mm_loadu_ps(b);
-    val_a = f(val_a, val_b);
-    _mm_storeu_ps(a, val_a);
   }
 };
 


### PR DESCRIPTION
Before this change, Vector<T> methods would operate on pointers, performing load/store as part of applying the operation. Now, Vector<T> instead operates on SIMD vector types. This allows us to perform operations together in Array without unnecessary load/stores and looping.